### PR TITLE
Avoid hang when POST/PUT/PATCH with empty body

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -105,7 +105,7 @@ module.exports = async (options) => {
         followRedirect,
         maxRedirects,
         timeout: timeoutSecs * 1000,
-        body: payload,
+        body: typeof payload === 'undefined' && /PATCH|POST|PUT/i.test(method) ? '' : payload,
         throwHttpErrors: throwOnHttpErrors,
         isStream: true,
         decompress: false,


### PR DESCRIPTION
Stream based POST requests made _without_ a body will hang unless `payload` is explicitly set as an empty string. This PR hides this implementation detail so you can make a POST request (that dosen't require a body) without needing to remember to also include `payload: ''` in the options.

**Taken from the Got README:** "Note: While got.post('https://example.com') resolves, got.stream.post('https://example.com') will hang indefinitely until a body is provided. If there's no body on purpose, remember to .end() the stream or set the body option to an empty string."